### PR TITLE
Add default browser support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 PORT=3000
-# Add any other environment variables here
+BROWSER_PATH=/path/to/your/browser  # Optional: specify custom browser path

--- a/src/DVSATestChecker.js
+++ b/src/DVSATestChecker.js
@@ -1,6 +1,7 @@
 const puppeteer = require('puppeteer-extra');
 const StealthPlugin = require('puppeteer-extra-plugin-stealth');
 const AdblockerPlugin = require('puppeteer-extra-plugin-adblocker');
+const defaultBrowser = require('default-browser');
 
 puppeteer.use(StealthPlugin());
 puppeteer.use(AdblockerPlugin({ blockTrackers: true }));
@@ -13,8 +14,34 @@ class DVSATestChecker {
   }
 
   async initialize() {
+    // Get default browser info
+    const browserInfo = await defaultBrowser();
+    
+    // Map browser names to their typical executable paths
+    const browserPaths = {
+      'brave': process.platform === 'win32'
+        ? 'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe'
+        : process.platform === 'darwin'
+          ? '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser'
+          : '/usr/bin/brave-browser',
+      'chrome': process.platform === 'win32'
+        ? 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
+        : process.platform === 'darwin'
+          ? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+          : '/usr/bin/google-chrome',
+      'firefox': process.platform === 'win32'
+        ? 'C:\\Program Files\\Mozilla Firefox\\firefox.exe'
+        : process.platform === 'darwin'
+          ? '/Applications/Firefox.app/Contents/MacOS/firefox'
+          : '/usr/bin/firefox'
+    };
+
+    const executablePath = process.env.BROWSER_PATH || browserPaths[browserInfo.name] || undefined;
+    console.log(`Using browser: ${browserInfo.name} at path: ${executablePath || 'default'}`);
+
     this.browser = await puppeteer.launch({
       headless: false,
+      executablePath,
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',


### PR DESCRIPTION
This PR adds support for using the system's default browser instead of always launching a new Chrome instance.

Changes:
1. Added `default-browser` package to dependencies
2. Modified `DVSATestChecker.js` to detect and use the system's default browser
3. Added browser path configuration option to `.env.example`
4. Added support for common browser paths on different operating systems

The changes will now:
- Detect the system's default browser
- Use the appropriate path for that browser based on the OS
- Fall back to the browser path from .env if specified
- If neither works, use Puppeteer's default browser

Testing steps:
1. Pull the changes
2. Run `npm install` to get the new dependency
3. Test with different browsers installed and set as default